### PR TITLE
Added `-std=gnu99` compiler option

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,5 +1,6 @@
 cc = gcc
-cflags = -Iinclude -g -Wall -Wextra -Wno-missing-field-initializers
+cflags = -Iinclude -std=gnu99 -g $
+    -W -Wall -Wextra -Wno-missing-field-initializers
 
 rule cc
   command = $cc $cflags -c $in -o $out


### PR DESCRIPTION
I can’t compile libhttp without a `-std=gnu**` option.

I use GCC 4.9.2.
